### PR TITLE
feat(local-system-user): add local system user role

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Contains common roles and playbooks.
 * [`core`](https://github.com/radiorabe/ansible-collection-common/tree/main/roles/core)
 * [`base`](https://github.com/radiorabe/ansible-collection-common/tree/main/roles/base)
 * [`files`](https://github.com/radiorabe/ansible-collection-common/tree/main/roles/files) (for quick and dirty file management)
+* [`local-system-user`](https://github.com/radiorabe/ansible-collection-common/tree/main/roles/local-system-user) (for local system user creation)
 
 ## License
 

--- a/roles/local-system-user/README.md
+++ b/roles/local-system-user/README.md
@@ -1,0 +1,40 @@
+# Ansible Role - radiorabe.common.local-system-user
+
+Manage local system users using [`ansible.builtin.user module`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html). Shell or password won't be set with this role.
+
+## Requirements
+
+None
+
+## Role Variables
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `username` | `not set` | Name of the user. **required** |
+| `home_directory` | `/home/{{username}}` | Home directory of the user. |
+| `usergroups` | `''` | Existing groups the user should be added to. |
+
+## Dependencies
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+## Example Playbook
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+```yaml
+- hosts: all
+  roles:
+    - role: radiorabe.common.local-system-user
+      vars:
+        username: local-sys
+    - role: radiorabe.common.local-system-user
+      vars:
+        username: virtualizer
+        home_directory: /var/lib/libvvirt/images/
+        usergroups: 'libvirt,qemu'
+```
+
+## License
+
+This role is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3 of the License.

--- a/roles/local-system-user/defaults/main.yml
+++ b/roles/local-system-user/defaults/main.yml
@@ -1,0 +1,4 @@
+# defaults for radiorabe.common.local-system-user
+
+home_directory: '/home/{{username}}'
+usergroups: ''

--- a/roles/local-system-user/meta/main.yml
+++ b/roles/local-system-user/meta/main.yml
@@ -1,0 +1,21 @@
+galaxy_info:
+  author: RaBe IT-Reaktion
+  description: Allow managing of local system users.
+  issue_tracker_url: https://github.com/radiorabe/ansible-collection-common/issues
+  license: AGPL-3.0-only
+  min_ansible_version: '2.9'
+  platforms:
+    - name: EL
+      versions:
+        - all
+    - name: Fedora
+      version:
+        - all
+  galaxy_tags:
+    - radiorabe
+    - foreman
+    - common
+    - system
+    - groups
+    - users
+dependencies: []

--- a/roles/local-system-user/tasks/main.yml
+++ b/roles/local-system-user/tasks/main.yml
@@ -6,5 +6,6 @@
     name: '{{ username }}'
     home: '{{ home_directory }}'
     groups: '{{ usergroups }}'
+    shell: '/sbin/nologin'
     system: true
     append: yes

--- a/roles/local-system-user/tasks/main.yml
+++ b/roles/local-system-user/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# tasks file for radiorabe.common.local-system-user
+
+- name: 'RaBe Base : Local System User : Add user {{ username }} with groups {{ usergroups }} and user home {{ home_directory }}.'
+  ansible.builtin.user:
+    name: '{{ username }}'
+    home: '{{ home_directory }}'
+    groups: '{{ usergroups }}'
+    system: true
+    append: yes


### PR DESCRIPTION
Add a generic  role for creating system users where home directory can be set and group membership(s) added.