### PR TITLE
fix(git_clone): Add missing become to task

### DIFF
--- a/roles/git_clone/tasks/main.yml
+++ b/roles/git_clone/tasks/main.yml
@@ -6,6 +6,7 @@
     name: git
     state: present
   delegate_to: "{{ '127.0.0.1' if radiorabe_git_local_clone else omit }}"
+  become: true
 
 - name: "RaBe Common : git_clone : Clone git repository {{ 'locally' if radiorabe_git_local_clone else 'on remote host' }}"
   ansible.builtin.git: "{{ item }}" # noqa: latest args


### PR DESCRIPTION
The task for checking if git is installed needs to be run with higher privileges apparently. Otherwise the playbook on foreman fails there.