### PR TITLE
fix(git_clone): Remove check for git in foreman

### DIFF
--- a/roles/git_clone/tasks/main.yml
+++ b/roles/git_clone/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 # tasks file for radiorabe.common.git
 
-- name: "RaBe Common : git_clone : Ensure required package is installed {{ 'locally' if radiorabe_git_local_clone else 'on remote host' }}"
+- name: "RaBe Common : git_clone : Ensure required package is installed"
   ansible.builtin.package:
     name: git
     state: present
-  delegate_to: "{{ '127.0.0.1' if radiorabe_git_local_clone else omit }}"
+  when: not radiorabe_git_local_clone
 
 - name: "RaBe Common : git_clone : Clone git repository {{ 'locally' if radiorabe_git_local_clone else 'on remote host' }}"
   ansible.builtin.git: "{{ item }}" # noqa: latest args


### PR DESCRIPTION
This role fails if git checkout is done on foreman. We'll revisit as soon as this becomes a requirement.